### PR TITLE
Track tree patch completion timestamps

### DIFF
--- a/src/main/java/com/dailytree/DailyTreeRunsPlugin.java
+++ b/src/main/java/com/dailytree/DailyTreeRunsPlugin.java
@@ -1,11 +1,16 @@
 package com.dailytree;
 
 import com.google.inject.Provides;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.EnumMap;
+import java.util.Map;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
@@ -18,34 +23,100 @@ import net.runelite.client.plugins.PluginDescriptor;
 )
 public class DailyTreeRunsPlugin extends Plugin
 {
-	@Inject
-	private Client client;
+        private static final String CONFIG_GROUP = "dailytreeruns";
+        private static final String LAST_COMPLETED_KEY_PREFIX = "lastCompleted.";
+        private static final Duration RESET_DURATION = Duration.ofDays(1);
 
-	@Inject
+        @Inject
+        private Client client;
+
+        @Inject
         private DailyTreeRunsConfig config;
 
-	@Override
-	protected void startUp() throws Exception
-	{
+        @Inject
+        private ConfigManager configManager;
+
+        private final Map<TreePatch, Boolean> patchStates = new EnumMap<>(TreePatch.class);
+
+        @Override
+        protected void startUp() throws Exception
+        {
                 log.info("Daily Tree Runs started!");
-	}
+                checkPatches();
+        }
 
-	@Override
-	protected void shutDown() throws Exception
-	{
+        @Override
+        protected void shutDown() throws Exception
+        {
                 log.info("Daily Tree Runs stopped!");
-	}
+                patchStates.clear();
+        }
 
-	@Subscribe
-	public void onGameStateChanged(GameStateChanged gameStateChanged)
-	{
-		if (gameStateChanged.getGameState() == GameState.LOGGED_IN)
-		{
+        @Subscribe
+        public void onGameStateChanged(GameStateChanged gameStateChanged)
+        {
+                if (gameStateChanged.getGameState() == GameState.LOGGED_IN)
+                {
+                        checkPatches();
                         client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "Daily Tree Runs says " + config.greeting(), null);
-		}
-	}
+                }
+        }
 
-	@Provides
+        @Subscribe
+        public void onChatMessage(ChatMessage chatMessage)
+        {
+                if (chatMessage.getType() != ChatMessageType.GAMEMESSAGE)
+                {
+                        return;
+                }
+
+                String message = chatMessage.getMessage();
+                for (TreePatch patch : TreePatch.values())
+                {
+                        if (message.contains(patch.getDisplayName()))
+                        {
+                                markPatchCompleted(patch);
+                        }
+                }
+        }
+
+        private void checkPatches()
+        {
+                Instant now = Instant.now();
+                for (TreePatch patch : TreePatch.values())
+                {
+                        long lastCompletion = getLastCompletion(patch);
+                        boolean completed = lastCompletion > 0 && now.minus(RESET_DURATION).toEpochMilli() < lastCompletion;
+                        patchStates.put(patch, completed);
+
+                        if (!completed)
+                        {
+                                client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", patch.getDisplayName() + " is ready for a new run.", null);
+                        }
+                }
+        }
+
+        private long getLastCompletion(TreePatch patch)
+        {
+                String key = LAST_COMPLETED_KEY_PREFIX + patch.name();
+                String value = configManager.getConfiguration(CONFIG_GROUP, key);
+                return value == null ? 0L : Long.parseLong(value);
+        }
+
+        private void setLastCompletion(TreePatch patch, long time)
+        {
+                String key = LAST_COMPLETED_KEY_PREFIX + patch.name();
+                configManager.setConfiguration(CONFIG_GROUP, key, time);
+        }
+
+        private void markPatchCompleted(TreePatch patch)
+        {
+                long now = Instant.now().toEpochMilli();
+                setLastCompletion(patch, now);
+                patchStates.put(patch, true);
+        }
+
+        @Provides
         DailyTreeRunsConfig provideConfig(ConfigManager configManager)
         {
                 return configManager.getConfig(DailyTreeRunsConfig.class);

--- a/src/main/java/com/dailytree/TreePatch.java
+++ b/src/main/java/com/dailytree/TreePatch.java
@@ -1,0 +1,17 @@
+package com.dailytree;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum TreePatch
+{
+        LUMBRIDGE("Lumbridge"),
+        TAVERLEY("Taverley"),
+        VARROCK("Varrock"),
+        FALADOR("Falador"),
+        FARMING_GUILD("Farming Guild");
+
+        private final String displayName;
+}


### PR DESCRIPTION
## Summary
- Track individual tree patch completion times using the ConfigManager
- Determine when patches are due by checking timestamps on startup/login
- Automatically reset patch states after 24 hours or when a harvest message is seen

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_689d66c36e4483288e0326ebcf060ddf